### PR TITLE
Adding CC-By-SA requirements for attribution

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1,3 +1,8 @@
+Original Contribution by [George Stocker](http://stackoverflow.com/users/16587/george-stocker) on [Stack Overflow](http://stackoverflow.com)
+
+Original Source: [Free Programming books](http://stackoverflow.com/revisions/392926/175)
+
+
 ### Index
 * [Ada](#ada)
 * [Agda](#agda)


### PR DESCRIPTION
Adding the attribution requirements as stated in this blog post: http://blog.stackoverflow.com/2009/06/attribution-required/.  Only added it to the actual markdown file that was created from the original answer on Stack Overflow.

 A reading of the attribution requirements does not seem to indicate that a sole reference in the readme.md is enough to satisfy the CC-By-SA requirements for attribution.