### PR TITLE
Add "OCPJP6 Resumen Español"

### DIFF
--- a/free-programming-books-es.md
+++ b/free-programming-books-es.md
@@ -152,6 +152,7 @@
 * [Arquitectura Java Sólida](http://www.arquitecturajava.com/)
 * [Desarrollo de proyectos informáticos con Java](http://www3.uji.es/~belfern/pdf/libroJavaConTapa.pdf) (PDF)
 * [Notas de Introducción al Lenguaje de Programación Java](http://www.matematicas.unam.mx/jloa/publicaciones/introduccionJava.pdf), por Jorge L. Ortega Arjona, UNAM (PDF)
+* [OCPJP6 Resumen Español](https://github.com/PabloReyes/ocpjp-resumen-espanol), por Pablo Reyes Almagro (PDF)
 * [Pensando la computación como un científico (con Java)](http://www.ungs.edu.ar/areas/publicaciones/476/pensando-la-computacion-como-un-cientifico.html)
 * [PlugIn Tapestry: Desarrollo de aplicaciones y páginas web con Apache Tapestry](http://picodotdev.github.io/blog-bitix/2014/02/libro-sobre-desarrollo-de-aplicaciones-con-apache-tapestry/) ([PDF](http://picodotdev.github.io/blog-bitix/assets/custom/PlugInTapestry.pdf)) ([EPUB](http://picodotdev.github.io/blog-bitix/assets/custom/PlugInTapestry.epub)) ([MOBI](http://picodotdev.github.io/blog-bitix/assets/custom/PlugInTapestry.mobi))
 * [Programación Orientada a Objetos en Java](http://fcasua.contad.unam.mx/apuntes/interiores/docs/98/opt/java.pdf) (PDF)


### PR DESCRIPTION
Add PDF book to prepare OCPJP6 Java Certification.

First time I added it at the end of the "Java" list instead of in alphabetical order (https://github.com/vhf/free-programming-books/pull/1248). 