### PR TITLE
Fixed raspberry pi link

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -144,7 +144,7 @@ Original Source: [Free Programming books](http://stackoverflow.com/revisions/392
 * [QML](#qml)
 * [R](#r)
 * [Racket](#racket)
-* [Raspberry Pi] (#rpi)
+* [Raspberry Pi] (#raspberry-pi)
 * [REBOL](#rebol)
 * [Ruby](#ruby)
     * [RSpec](#rspec)


### PR DESCRIPTION
Previously linked to #rpi, now links to #raspberry-pi