### PR TITLE
Removed "HTML5 for Web Designers" since it's obviously not free anymore ...

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1006,7 +1006,6 @@ Original Source: [Free Programming books](http://stackoverflow.com/revisions/392
 * [HTML Dog Tutorials](http://www.htmldog.com/)
 * [HTML5 Canvas](http://chimera.labs.oreilly.com/books/1234000001654/index.html) - Steve Fulton & Jeff Fulton
 * [HTML5 for Publishers](http://chimera.labs.oreilly.com/books/1234000000770/index.html) - Sanders Kleinfeld
-* [HTML5 For Web Designers](http://html5forwebdesigners.com/) - Jeremy Keith
 * [Learn CSS Layout](http://learnlayout.com/)
 * [Scalable and Modular Architecture for CSS](http://smacss.com) - Jonathan Snook
 * [Web Audio API](http://chimera.labs.oreilly.com/books/1234000001552) - Boris Smus


### PR DESCRIPTION
...(http://html5forwebdesigners.com).

Signed-off-by: Sebastian Herrmann <sebastian@herrherrmann.net>