### PR TITLE
Remove Railscasts from books.

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1633,7 +1633,6 @@ See also [TeX](#tex)
 
 
 #### Ruby on Rails
-* [Railscasts - Ruby on Rails Screencasts](http://railscasts.com/)
 * [A community-driven Rails style guide](https://github.com/bbatsov/rails-style-guide)
 * [Kestrels, Quirky Birds, and Hopeless Egocentricity](https://leanpub.com/combinators/read)
 * [Learn Ruby on Rails as You Modify a Craigslist Clone](http://www.thinkful.com/learn/ruby-on-rails-tutorial/)


### PR DESCRIPTION
Remove Railscasts from list of free books since it is already in the screencasts list in `free-podcasts-screencasts-en.md`.