### PR TITLE
remove broken link for Agile Java

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1061,7 +1061,6 @@ Original Source: [Free Programming books](http://stackoverflow.com/revisions/392
 
 ### Java
 * [3D Programming in Java](http://www.mat.uniroma2.it/~picard/SMC/didattica/materiali_did/Java/Java_3D/Java_3D_Programming.pdf) - Daniel Selman
-* [Agile Java](http://www.langrsoft.com/ftp/agileJava/) - Jeff Langr
 * [Animation/Games in Java](http://www.heatonresearch.com/articles/series/3)
 * [Apache Jakarta Commons: Reusable Java Components](http://ptgmedia.pearsoncmg.com/images/0131478303/downloads/Iverson_book.pdf) - Will Iverson
 * [Artificial Intelligence - Foundation of Computational Agents](http://artint.info/html/ArtInt.html)


### PR DESCRIPTION
Agile Java original source website was deleted. This PR removes the broken link to this book and resolves #1378 