### PR TITLE
Adding NPTEL

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -458,6 +458,7 @@ Original Source: [Free Programming books](http://stackoverflow.com/revisions/392
 * [edX](https://www.edx.org/)
 * [FutureLearn](https://www.futurelearn.com/)
 * [MIT OCW](http://ocw.mit.edu/OcwWeb/web/home/home/index.htm)
+* [NPTEL](http://nptel.ac.in/courses.php?disciplineId=106)
 * [Udacity](https://www.udacity.com/)
 
 


### PR DESCRIPTION
Adding NPTEL (National Programme on Technology Enhanced Learning), e-learning through online Web and Video courses in Engineering