### PR TITLE
Added new Python book "Automate the Boring Stuff"

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1499,6 +1499,7 @@ See also [TeX](#tex)
 * [A Beginner's Python Tutorial](http://en.wikibooks.org/wiki/A_Beginner%27s_Python_Tutorial)
 * [A Bit of Python and Other Things](http://jessenoller.com/good-to-great-python-reads/)
 * [A Guide to Python's Magic Methods](http://www.rafekettler.com/magicmethods.html) - Rafe Kettler
+* [Automate the Boring Stuff](http://automatetheboringstuff.com/chapter0/) - Al Sweigart
 * [Biopython](http://biopython.org/DIST/docs/tutorial/Tutorial.pdf)
 * [Building Skills in Object-Oriented Design (Python)](http://www.itmaybeahack.com/book/oodesign-python-2.1/latex/BuildingSkillsinOODesign.pdf) (PDF) (2.1.1)
 * [Building Skills in Python](http://www.itmaybeahack.com/book/python-2.6/latex/BuildingSkillsinPython.pdf) (PDF) (2.6)


### PR DESCRIPTION
Added Al Sweigart's newest free book, "Automate the Boring Stuff", starting at chapter 0. You could use http://automatetheboringstuff.com instead of http://automatetheboringstuff.com/chapter0/ but I figured chapter 0 would be more appropriate due to it being the first page of the book and both links have the navigable table of context.