### PR TITLE
Changed link for "TeX pour l'Impatient"

### DIFF
--- a/free-programming-books-fr.md
+++ b/free-programming-books-fr.md
@@ -149,7 +149,7 @@ les problèmes](http://www.pearson.fr/livre/?GCOI=27440100048330), Annexe B du 
 
 #### TeX
 
-* [TeX pour l'Impatient](ftp://tug.org/tex/impatient/fr/fbook.pdf), par Paul Abrahams, Kathryn Hargreaves, and Karl Berry, trad. Marc Chaudemanche
+* [TeX pour l'Impatient](http://www.apprendre-en-ligne.net/LaTeX/teximpatient.pdf), par Paul Abrahams, Kathryn Hargreaves, and Karl Berry, trad. Marc Chaudemanche
 
 ### Lisp
 * [Introduction à la programmation en Common Lisp](http://www.algo.be/logo1/lisp/intro-lisp.pdf) par Francis Leboutte


### PR DESCRIPTION
The link for "TeX pour l'Impatient" was a FTP one and not working. I changed it for http://www.apprendre-en-ligne.net/LaTeX/teximpatient.pdf

And the FR list does not need alphabetization as of now.