### PR TITLE
Fixed link for ebook "Exploring ES6"

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1176,7 +1176,7 @@ Original Source: [Free Programming books](http://stackoverflow.com/revisions/392
 * [Dev Docs](http://devdocs.io/)
 * [Developing Backbone.js Applications](http://addyosmani.github.io/backbone-fundamentals/) - Addy Osmani
 * [Eloquent JavaScript 2nd edition](http://eloquentjavascript.net/) - Marijn Haverbeke
-* [Exploring ES6](https://leanpub.com/exploring-es6/read) - Dr. Axel Rauschmayer
+* [Exploring ES6](http://exploringjs.com/es6/) - Dr. Axel Rauschmayer
 * [Google JavaScript Style Guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)
 * [Human Javascript](http://read.humanjavascript.com/)
 * [JavaScript Allongé](https://leanpub.com/javascript-allonge/read) - Reginald Braithwaite


### PR DESCRIPTION
[http://exploringjs.com/es6/](http://exploringjs.com/es6/) is the new link for Dr. Axel Raushmayer *Exploring ES6* ebook