### PR TITLE
Alphabetizing 'en' checked

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,7 +17,7 @@ TODO
     - [ ] bg
     - [ ] de
     - [x] es
-    - [ ] en
+    - [x] en
     - [x] fa_IR
     - [ ] fr
     - [ ] it


### PR DESCRIPTION
The 'en' option is checked since the capitalization has already been done. Leaving it unchecked might misguide those willing to contribute.