### PR TITLE
Correct minor typos

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1036,7 +1036,7 @@ Original Source: [Free Programming books](http://stackoverflow.com/revisions/392
 
 ### Haskell
 * [A Gentle Introduction to Haskell](http://www.haskell.org/tutorial/)
-* [A Haskell School of Music](http://haskell.cs.yale.edu/?post_type=publication&p=112) (PDF) (work in progress)
+* [The Haskell School of Music](http://haskell.cs.yale.edu/?post_type=publication&p=112) (PDF) (work in progress)
 * [Anatomy of Programming Languages](http://www.cs.utexas.edu/~wcook/anatomy/) - William R. Cook
 * [Beautiful Code, Compelling Evidence](http://vis.renci.org/jeff/2009/01/16/beautiful-code-compelling-evidence/) (PDF)
 * [Exploring Generic Haskell](http://www.andres-loeh.de/ExploringGH.pdf) - Andres Löh
@@ -1618,7 +1618,7 @@ See also [TeX](#tex)
 * [Effective Django](http://effectivedjango.com/) (1.5)
 * [Getting started with Django](http://gettingstartedwithdjango.com/) (video)
 * [Tango With Django](http://www.tangowithdjango.com/) (1.5)
-* [Test-Driven Web Development with Python](http://chimera.labs.oreilly.com/books/1234000000754/index.html) (1.7)
+* [Test-Driven Web Development with Python](http://chimera.labs.oreilly.com/books/1234000000754/index.html) (1.8)
 * [The Django book](http://www.djangobook.com/en/2.0/) (1.4 but mostly 1.0)
 
 


### PR DESCRIPTION
change "A" to "The" in "The Haskell School of Music" to match the title on the site.
change Django version number on "Test-Driven Web Development with Python" to 1.8. As the author notes [here](http://chimera.labs.oreilly.com/books/1234000000754/pr02.html#ftn.id619210), he updated the book for 1.8 in Spring 2015, since it's an LTS version.