### PR TITLE
'Start Developing iOS Apps' Apple guide changes

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1104,7 +1104,8 @@ Original Source: [List of freely available programming books](http://web.archive
 * [iOS 8 App Development Essentials](http://www.techotopia.com/index.php/IOS_8_App_Development_Essentials)
 * [iOS Succinctly, Syncfusion](http://www.syncfusion.com/resources/techportal/ebooks/ios) (PDF, Kindle) *(Just fill the fields with any values)*
 * [NSHipster](http://nshipster.com/#archive) (Resource)
-* [Start Developing iOS Apps Today](https://developer.apple.com/library/ios/referencelibrary/GettingStarted/RoadMapiOS/RoadMapiOS.pdf) (PDF)
+* [Start Developing iOS Apps Today (Objective-C) - Last updated 22.10.2013](http://everythingcomputerscience.com/books/RoadMapiOS.pdf) (PDF)
+* [Start Developing iOS Apps (Swift)](https://developer.apple.com/library/prerelease/ios/referencelibrary/GettingStarted/DevelopiOSAppsSwift/index.html) (HTML)
 
 
 ### Isabelle/HOL


### PR DESCRIPTION
Changes made in the iOS section:
- Link to `Start Developing iOS Apps Today (Objective-C)` is dead, replaced with one alive found on Google.
- Added the Swift version (only one currently available and updated, on Apple's website) of the guide (only available in HTML).