### PR TITLE
Adopt a Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,50 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of  
+fostering an open and welcoming community, we pledge to respect all people who  
+contribute through reporting issues, posting feature requests, updating  
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free  
+experience for everyone, regardless of level of experience, gender, gender  
+identity and expression, sexual orientation, disability, personal appearance,  
+body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery  
+* Personal attacks  
+* Trolling or insulting/derogatory comments  
+* Public or private harassment  
+* Publishing other's private information, such as physical or electronic  
+  addresses, without explicit permission  
+* Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or  
+reject comments, commits, code, wiki edits, issues, and other contributions  
+that are not aligned to this Code of Conduct, or to ban temporarily or  
+permanently any contributor for other behaviors that they deem inappropriate,  
+threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to  
+fairly and consistently applying these principles to every aspect of managing  
+this project. Project maintainers who do not follow or enforce the Code of  
+Conduct may be permanently removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces  
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be  
+reported by contacting a project maintainer at victorfelder at gmail.com. All  
+complaints will be reviewed and investigated and will result in a response that  
+is deemed necessary and appropriate to the circumstances. Maintainers are  
+obligated to maintain confidentiality with regard to the reporter of an  
+incident.  
+
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],  
+version 1.3.0, available at
+[http://contributor-covenant.org/version/1/3/0/][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/3/0/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,48 +1,48 @@
 # Contributor Code of Conduct
 
-As contributors and maintainers of this project, and in the interest of  
-fostering an open and welcoming community, we pledge to respect all people who  
-contribute through reporting issues, posting feature requests, updating  
+As contributors and maintainers of this project, and in the interest of
+fostering an open and welcoming community, we pledge to respect all people who
+contribute through reporting issues, posting feature requests, updating
 documentation, submitting pull requests or patches, and other activities.
 
-We are committed to making participation in this project a harassment-free  
-experience for everyone, regardless of level of experience, gender, gender  
-identity and expression, sexual orientation, disability, personal appearance,  
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
 body size, race, ethnicity, age, religion, or nationality.
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery  
-* Personal attacks  
-* Trolling or insulting/derogatory comments  
-* Public or private harassment  
-* Publishing other's private information, such as physical or electronic  
-  addresses, without explicit permission  
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic
+  addresses, without explicit permission
 * Other unethical or unprofessional conduct
 
-Project maintainers have the right and responsibility to remove, edit, or  
-reject comments, commits, code, wiki edits, issues, and other contributions  
-that are not aligned to this Code of Conduct, or to ban temporarily or  
-permanently any contributor for other behaviors that they deem inappropriate,  
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
 threatening, offensive, or harmful.
 
-By adopting this Code of Conduct, project maintainers commit themselves to  
-fairly and consistently applying these principles to every aspect of managing  
-this project. Project maintainers who do not follow or enforce the Code of  
+By adopting this Code of Conduct, project maintainers commit themselves to
+fairly and consistently applying these principles to every aspect of managing
+this project. Project maintainers who do not follow or enforce the Code of
 Conduct may be permanently removed from the project team.
 
-This code of conduct applies both within project spaces and in public spaces  
+This code of conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be  
-reported by contacting a project maintainer at victorfelder at gmail.com. All  
-complaints will be reviewed and investigated and will result in a response that  
-is deemed necessary and appropriate to the circumstances. Maintainers are  
-obligated to maintain confidentiality with regard to the reporter of an  
-incident.  
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting a project maintainer at victorfelder at gmail.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. Maintainers are
+obligated to maintain confidentiality with regard to the reporter of an
+incident.
 
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],  
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 1.3.0, available at
 [http://contributor-covenant.org/version/1/3/0/][version]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,8 @@
-## Contributor license agreement
+## Contributor License Agreement
 By contributing you agree to the [LICENSE](https://github.com/vhf/free-programming-books/blob/master/LICENSE) of this repository.
+
+## Contributor Code of Conduct
+By contributing you agree to respect the [Code of Conduct](https://github.com/vhf/free-programming-books/blob/master/CODE_OF_CONDUCT.md) of this repository.
 
 ## In a nutshell
 1. "An link to easily download a book" is not alway a link to a *free* book. Please only contribute free content. Make sure it's free.


### PR DESCRIPTION
I think it's a shame that the second most popular github repository does not have a code of conduct and I intend to fix this. We never needed a code of conduct, we don't want to need a code of conduct and that's why we need a code of conduct.

I submit this as a PR instead of committing directly to master because I want to allow some debate on this issue. I will merge this PR in a week or so, if there is no good case against it.