### PR TITLE
Added new Git course link

### DIFF
--- a/free-programming-books-pt_BR.md
+++ b/free-programming-books-pt_BR.md
@@ -62,7 +62,7 @@
 * [Aprendendo Git](http://www.slideshare.net/bismarckjunior/aprendendo-git)
 * [Git - guia prático](http://rogerdudler.github.io/git-guide/index.pt_BR.html)
 * [Git Magic](http://www-cs-students.stanford.edu/~blynn/gitmagic/intl/pt_br/)
-* [Minicurso - Controle de Versão usando o Git](https://github.com/ltiaunesp/Git-Minicurso)
+* [Minicurso - Controle de Versão usando o Git](https://github.com/ltiaunesp/Git-Minicurso) - LTIA UNESP
 * [Pro Git](http://git-scm.com/book/pt-br/)
 
 

--- a/free-programming-books-pt_BR.md
+++ b/free-programming-books-pt_BR.md
@@ -60,9 +60,10 @@
 ### Git
 
 * [Aprendendo Git](http://www.slideshare.net/bismarckjunior/aprendendo-git)
-* [Git Magic](http://www-cs-students.stanford.edu/~blynn/gitmagic/intl/pt_br/)
-* [Pro Git](http://git-scm.com/book/pt-br/)
 * [Git - guia prático](http://rogerdudler.github.io/git-guide/index.pt_BR.html)
+* [Git Magic](http://www-cs-students.stanford.edu/~blynn/gitmagic/intl/pt_br/)
+* [Minicurso - Controle de Versão usando o Git](https://github.com/ltiaunesp/Git-Minicurso)
+* [Pro Git](http://git-scm.com/book/pt-br/)
 
 
 ### Haskell


### PR DESCRIPTION
I added a new link to a Git course that my team worked on. It's a free course, based on GitHub.
I also changed the order of links on the Git section to meet the alphabetical order.