### PR TITLE
C++ Annotations book was moved to new host

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -847,7 +847,7 @@ Original Source: [List of freely available programming books](http://web.archive
 
 ### C++
 
-* [C++ Annotations](http://cppannotations.sourceforge.net)
+* [C++ Annotations](https://fbb-git.github.io/cppannotations/)
 * [C++ Cookbook](http://staff.ppu.edu/dkhalid/O'Reilly%20-%20C++%20Cookbook%20%282007%29.pdf) (PDF)
 * [C++ GUI Programming With Qt 3](http://www.computer-books.us/cpp_0010.php)
 * [C++ Succinctly, Syncfusion](https://www.syncfusion.com/resources/techportal/ebooks/cplusplus) (PDF, Kindle) *(Just fill the fields with any values)*


### PR DESCRIPTION
The old one on SourceForge is not used anymore.