### PR TITLE
replace unrelated party link with internet archive link

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -516,7 +516,7 @@ Original Source: [List of freely available programming books](http://web.archive
 * [HTTP Succinctly, Syncfusion](https://www.syncfusion.com/resources/techportal/ebooks/http) (PDF, Kindle) *(Just fill the fields with any values)*
 * [HTTP2 Explained](http://daniel.haxx.se/http2/) - Daniel Stenberg
 * [The TCP/IP Guide](http://www.tcpipguide.com/free/t_toc.htm)
-* [Understanding IP Addressing: Everything you ever wanted to know](http://www.di.unipi.it/~ricci/501302.pdf) (PDF)
+* [Understanding IP Addressing: Everything you ever wanted to know](https://web.archive.org/web/20080401000000*/http://www.3com.com/other/pdfs/infra/corpinfo/en_US/501302.pdf) (PDF)
 * [ZeroMQ Guide](http://zguide.zeromq.org/page%3Aall)
 
 


### PR DESCRIPTION
Judgement call. This is a 3Com "white paper". Though 3Com has copyright, white papers are typically freely distributed to advance a technology. It doesn't appear as if Prof. Ricci has anything to do with the white paper. The ooriginal link was likely lost on 3com's acquisition. I suggest replacing it with https://web.archive.org/web/20080401000000*/http://www.3com.com/other/pdfs/infra/corpinfo/en_US/501302.pdf
because if the owner wants to remove it they can do so.