### PR TITLE
Update dead link for "Mostly Adequate Guide to Functional Programming"

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -589,7 +589,7 @@ Original Source: [List of freely available programming books](http://web.archive
 #### Programming Paradigms
 
 * [Introduction to Functional Programming](http://www.cl.cam.ac.uk/teaching/Lectures/funprog-jrh-1996/) (class lectures and slides)
-* [Mostly Adequate Guide to Functional Programming](https://drboolean.gitbooks.io/mostly-adequate-guide/)
+* [Mostly Adequate Guide to Functional Programming](https://www.gitbook.com/book/drboolean/mostly-adequate-guide/details)
 * [Type Theory and Functional Programming](https://www.cs.kent.ac.uk/people/staff/sjt/TTFP/)
 
 


### PR DESCRIPTION
Original link returned 404