### PR TITLE
Fixed ("C" to "C#")

### DIFF
--- a/free-podcasts-screencasts-en.md
+++ b/free-podcasts-screencasts-en.md
@@ -28,7 +28,7 @@
 * [Podcast] - [Adventures in Angular - DevChat.tv](https://devchat.tv/adventures-in-angular/)
 
 
-### C#
+### C&#x23;
 
 * [Screencast] - [How to program in C# - Beginner Course | Brackeys](https://www.youtube.com/playlist?list=PLPV2KyIb3jR6ZkG8gZwJYSjnXxmfPAl51)
 

--- a/free-podcasts-screencasts-en.md
+++ b/free-podcasts-screencasts-en.md
@@ -2,7 +2,7 @@
 
 * [Android](#android)
 * [Angular JS](#angularjs)
-* [C#](#csharp)
+* [C#](#c)
 * [C++](#c-1)
 * [CSS](#css)
 * [Elixir](#elixir)


### PR DESCRIPTION
Trailing hash signs (#) in headers are ignored. I fixed that with a HTML escape sequence.