### PR TITLE
Issue #1797 fixed

### DIFF
--- a/free-courses-en.md
+++ b/free-courses-en.md
@@ -38,7 +38,7 @@
 
 ### Android
 
-* [Creative, Serious and Playful Science of Android Apps](https://www.coursera.org/course/androidpart1apps101)
+* [Creative, Serious and Playful Science of Android Apps](https://www.coursera.org/course/androidapps101/)
 * [Programming Cloud Services for Android Handheld Systems](https://www.coursera.org/course/mobilecloudprogram)
 * [Programming Mobile Applications for Android Handheld Systems pt. 1](https://www.coursera.org/course/android)
 * [Programming Mobile Applications for Android Handheld Systems pt. 2](https://www.coursera.org/course/androidpart2)


### PR DESCRIPTION
In the android section, a link was taking to a 404 page. The link was mentioned as (https://www.coursera.org/course/androidpart1apps101) instead of (https://www.coursera.org/course/androidapps101/)

PR to close #1797 