### PR TITLE
Add notation for Ansible Up and Running Book

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -433,7 +433,7 @@
 
 * [97 Things Every Programmer Should Know - Extended](https://leanpub.com/97-Things-Every-Programmer-Should-Know-Extended)
 * [A Mathematical Theory of Communication](http://ieeexplore.ieee.org/stamp/stamp.jsp?reload=true&arnumber=6773024&tp=) - Claude E.Shannon
-* [Ansible Up & Running](https://www.ansible.com/blog/free-ansible-book)
+* [Ansible Up & Running (first three chapters, email required)](https://www.ansible.com/blog/free-ansible-book)
 * [Asterisk™: The Definitive Guide](http://asteriskdocs.org/en/3rd_Edition/asterisk-book-html-chunk/index.html)
 * [Barcode Overview](http://www.tec-it.com/download/PDF/Barcode_Reference_EN.pdf) (PDF)
 * [Come, Let's Play: Scenario-Based Programming Using Live Sequence Charts](http://www.wisdom.weizmann.ac.il/~playbook/)


### PR DESCRIPTION
The book is available for first three chapters, and email registration is required to get it.