### PR TITLE
previous link of Google Java Style Guide is dead

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1219,7 +1219,7 @@
 * [Core Servlets and JavaServer Pages](http://pdf.coreservlets.com) - Marty Hall and Larry Brown
 * [Data Structures and Algorithms with Object-Oriented Design Patterns in Java](http://www.brpreiss.com/books/opus5/html/page9.html)
 * [Data Structures in Java for the Principled Programmer](http://dept.cs.williams.edu/~bailey/JavaStructures/Book_files/JavaStructures.pdf) (PDF)
-* [Google's Java Style Guide](http://google-styleguide.googlecode.com/svn/trunk/javaguide.html)
+* [Google's Java Style Guide](https://google.github.io/styleguide/javaguide.html)
 * [Introduction to Computer science using Java](http://chortle.ccsu.edu/java5/index.html)
 * [Introduction to Programming in Java](http://introcs.cs.princeton.edu/java/home/) - Robert Sedgewick and Kevin Wayne
 * [Introduction to Programming Using Java](http://math.hws.edu/javanotes/) - David J. Eck


### PR DESCRIPTION
the link to **Google Java Style Guide** 

> http://google-styleguide.googlecode.com/svn/trunk/javaguide.html

 is broken . after googling i found this link 

> https://google.github.io/styleguide/javaguide.html

 which means they shifted this guide from svn to github.