### PR TITLE
Update Ubuntu Server guide to 16.04

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1395,7 +1395,7 @@ For resources on Angular, Backbone, D3, Dojo, Ember, Express, jQuery, Knockout, 
 * [The Linux System Administrator's Guide](http://www.tldp.org/LDP/sag/html/index.html)
 * [The Python GTK+ 3 Tutorial](http://python-gtk-3-tutorial.readthedocs.org/en/latest/)
 * [Ubuntu Pocket Guide and Reference](http://www.ubuntupocketguide.com/index_main.html)
-* [Ubuntu Server Guide](https://help.ubuntu.com/14.04/serverguide/serverguide.pdf) (PDF)
+* [Ubuntu Server Guide](https://help.ubuntu.com/16.04/serverguide/serverguide.pdf) (PDF)
 * [Upstart Intro, Cookbook and Best Practises](http://upstart.ubuntu.com/cookbook/)
 * [What Every Programmer Should Know About Memory](http://www.akkadia.org/drepper/cpumemory.pdf) (PDF)
 


### PR DESCRIPTION
The URL of the latest Ubuntu server guide is https://help.ubuntu.com/16.04/serverguide/serverguide.pdf, I just changed 14.04 to 16.04, and it still works. The document is slightly different, it has slightly more pages. It's still under CC BY-SA 3.0 Unported.