### PR TITLE
Fix a broken link to 'Practical PostgreSQL'

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1656,7 +1656,7 @@ For resources on Angular, Backbone, D3, Dojo, Ember, Express, jQuery, Knockout, 
 
 * [Postgres Official Documentation](http://www.postgresql.org/docs/)
 * [Postgres Succinctly](https://www.syncfusion.com/resources/techportal/ebooks/postgres) (PDF, Kindle) *(Just fill the fields with any values)*
-* [Practical PostgreSQL](https://www.commandprompt.com/ppbook/)
+* [Practical PostgreSQL](http://www.faqs.org/docs/ppbook/book1.htm)
 
 
 ### PowerShell


### PR DESCRIPTION
The original link is now a 404. I'm not sure if the authors intend this resource to remain free; if not, it should be removed. If so, here's a working link.