### PR TITLE
Add Self handbook

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -164,6 +164,7 @@
 * [Scilab](#scilab)
 * [Scratch](#scratch)
 * [Sed](#sed)
+* [Self](#self)
 * [Smalltalk](#smalltalk)
 * [Spark](#spark)
 * [SQL (implementation agnostic)](#sql-implementation-agnostic)
@@ -2010,6 +2011,11 @@ For resources on Angular, Backbone, D3, Dojo, Ember, Express, jQuery, Knockout, 
 ### Sed
 
 * [Sed - An Introduction and Tutorial](http://www.grymoire.com/Unix/Sed.html)
+
+
+### Self
+
+* [The Self Handbook](http://handbook.selflanguage.org/current/)
 
 
 ### Smalltalk


### PR DESCRIPTION
The official [Self language](http://www.selflanguage.org/) documentation.