### PR TITLE
Fixed broken Golang link in TR section

### DIFF
--- a/free-programming-books-tr.md
+++ b/free-programming-books-tr.md
@@ -71,7 +71,7 @@
 
 ### Go
 
-* [Go Turu](http://tur.a.golang.org.tr)
+* [Go Turu](https://go-tour-turkish.appspot.com/welcome/1)
 
 
 ### Html


### PR DESCRIPTION
Old broken link is replaced with the new one that works.