### PR TITLE
fix 404 for Google JavaScript Style Guide

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1289,7 +1289,7 @@
 * [Developing Backbone.js Applications](http://addyosmani.github.io/backbone-fundamentals/) - Addy Osmani
 * [Eloquent JavaScript 2nd edition](http://eloquentjavascript.net) - Marijn Haverbeke
 * [Exploring ES6](http://exploringjs.com/es6/) - Dr. Axel Rauschmayer
-* [Google JavaScript Style Guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)
+* [Google JavaScript Style Guide](https://github.com/google/styleguide/blob/gh-pages/javascriptguide.xml)
 * [Human Javascript](http://read.humanjavascript.com)
 * [JavaScript Allongé](https://leanpub.com/javascript-allonge/read) - Reginald Braithwaite
 * [JavaScript Bible](http://media.wiley.com/product_ancillary/28/07645334/DOWNLOAD/all.pdf) (PDF)


### PR DESCRIPTION
the guide's code has been switched to github. The old link was giving access to the xml source so i also do the same. However, i recommend to change it to the html page (the gold is free book, not free code!).

*so if you agree i can do the change*