### PR TITLE
Fixing a link

### DIFF
--- a/free-programming-books-fr.md
+++ b/free-programming-books-fr.md
@@ -152,7 +152,7 @@
 
 #### LaTeX
 
-* [LaTeX... pour le prof de maths !](http://math.univ-lyon1.fr/irem/IMG/pdf/LatexPourProfMaths.pdf) - Arnaud Gazagnes (PDF)
+* [LaTeX... pour le prof de maths !](http://math.univ-lyon1.fr/irem/IMG/pdf/LatexPourProfMaths3.pdf) - Arnaud Gazagnes (PDF)
 * [Tout ce que vous avez toujours voulu savoir sur LaTeX sans jamais oser le demander](http://framabook.org/tout-sur-latex/) - Vincent Lozano
 * [(Xe)LaTeX appliqué aux sciences humaines](http://geekographie.maieul.net/95) - Maïeul Rouquette
 


### PR DESCRIPTION
"LaTeX... pour le prof de maths !" led to a 404, just replaced it a functionnal link.