### PR TITLE
Archive link for "A Mathematical Theory of Communication"

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -441,7 +441,7 @@
 #### Misc
 
 * [97 Things Every Programmer Should Know - Extended](https://leanpub.com/97-Things-Every-Programmer-Should-Know-Extended)
-* [A Mathematical Theory of Communication](http://ieeexplore.ieee.org/stamp/stamp.jsp?reload=true&arnumber=6773024&tp=) - Claude E.Shannon
+* [A Mathematical Theory of Communication](https://archive.org/details/bstj27-4-623) - Claude E.Shannon
 * [Ansible Up & Running (first three chapters)](https://www.ansible.com/blog/free-ansible-book) *(account required)*
 * [Asterisk™: The Definitive Guide](http://asteriskdocs.org/en/3rd_Edition/asterisk-book-html-chunk/index.html)
 * [Barcode Overview](http://www.tec-it.com/download/PDF/Barcode_Reference_EN.pdf) (PDF)


### PR DESCRIPTION
This addresses issue #2058.

Per the Online Book Page at U Penn, BSTJ is presumed to be out of copyright: "The Bell System Technical Journal published its first issue in 1922. No copyright renewals are known to exist for issues of this journal. In 1984, after the breakup of the Bell System, The Bell System Technical Journal was renamed, and its current version is known as the Bell Labs Technical Journal."