### PR TITLE
added gitbu.ch

### DIFF
--- a/free-programming-books-de.md
+++ b/free-programming-books-de.md
@@ -78,6 +78,7 @@
 
 ### Git
 
+* [Das Git-Buch](http://gitbu.ch/) [PDF, EPUB]
 * [Git Magic](http://www-cs-students.stanford.edu/~blynn/gitmagic/intl/de/)
 * [Pro Git](http://git-scm.com/book/de/v1)
 


### PR DESCRIPTION
On 31.12.2015 the publisher "Open Source Press" closed his business. Now this book is available online for free unter the CreativeCommons-Licence.