### PR TITLE
broken sql pdf link replaced

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1518,7 +1518,7 @@ For resources on Angular, Backbone, D3, Dojo, Ember, Express, jQuery, Knockout, 
 ### MySQL
 
 * [MySQL Essentials](http://www.techotopia.com/index.php/MySQL_Essentials)
-* [MySQL Tutorial Excerpt](http://downloads.mysql.com/docs/mysql-tutorial-excerpt-5.1-en.pdf) (PDF)
+* [MySQL Tutorial Excerpt](http://downloads.mysql.com/docs/mysql-tutorial-excerpt-5.5-en.pdf) (PDF)
 
 
 ### Neo4J


### PR DESCRIPTION
For MySQL section:

[http://downloads.mysql.com/docs/mysql-tutorial-excerpt-5.1-en.pdf](http://downloads.mysql.com/docs/mysql-tutorial-excerpt-5.1-en.pdf)

Above broken URL replaced with following one:
[http://downloads.mysql.com/docs/mysql-tutorial-excerpt-5.5-en.pdf](http://downloads.mysql.com/docs/mysql-tutorial-excerpt-5.5-en.pdf)