### PR TITLE
Add 'Begin Latex in minutes'

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1384,10 +1384,10 @@ For resources on Angular, Backbone, D3, Dojo, Ember, Express, jQuery, Knockout, 
 
 #### LaTeX
 
-* [Arbirtrary LaTex Reference](http://latex.knobs-dials.com)
+* [Arbitrary LaTex Reference](http://latex.knobs-dials.com)
 * [LaTeX Wikibook](https://en.wikibooks.org/wiki/LaTeX)
 * [The Not So Short Introduction to LaTeX](https://tobi.oetiker.ch/lshort/lshort.pdf) (PDF)
-* [Begin LaTeX in minutes](https://github.com/VoLuong/Begin-Latex-in-minutes)
+* [Begin Latex in minutes](https://github.com/VoLuong/Begin-Latex-in-minutes)
 
 #### TeX
 

--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1387,7 +1387,7 @@ For resources on Angular, Backbone, D3, Dojo, Ember, Express, jQuery, Knockout, 
 * [Arbirtrary LaTex Reference](http://latex.knobs-dials.com)
 * [LaTeX Wikibook](https://en.wikibooks.org/wiki/LaTeX)
 * [The Not So Short Introduction to LaTeX](https://tobi.oetiker.ch/lshort/lshort.pdf) (PDF)
-
+* [Begin LaTeX in minutes](https://github.com/VoLuong/Begin-Latex-in-minutes)
 
 #### TeX
 


### PR DESCRIPTION
Added 'Begin Latex in minutes' to the 'LaTeX' section and fixed typos in 'Arbitrary Latex Reference' (Arbirtrary -> Arbitrary)