### PR TITLE
Update Oracle links

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1622,7 +1622,7 @@ For resources on Angular, Backbone, D3, Dojo, Ember, Express, jQuery, Knockout, 
 
 ### Oracle Server
 
-* [Oracle's Guides and Manuals](http://docs.oracle.com)
+* [Oracle's Guides and Manuals](https://docs.oracle.com)
 
 
 ### Parrot / Perl 6

--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -130,7 +130,6 @@
 * [OpenMP](#openmp)
 * [OpenResty](#openresty)
 * [OpenSCAD](#openscad)
-* [Oracle PL/SQL](#oracle-plsql)
 * [Oracle Server](#oracle-server)
 * [Parrot / Perl 6](#parrot--perl-6)
 * [PC-BSD](#pc-bsd)

--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1623,7 +1623,7 @@ For resources on Angular, Backbone, D3, Dojo, Ember, Express, jQuery, Knockout, 
 
 ### Oracle Server
 
-* [Oracle's Guides and Manuals](http://tahiti.oracle.com)
+* [Oracle's Guides and Manuals](http://docs.oracle.com)
 
 
 ### Parrot / Perl 6


### PR DESCRIPTION
The `tahiti.oracle.com` documentation index was switched off some time ago, so updated it to `docs.oracle.com`. I also note there was no section for Oracle PL/SQL so I removed that entry from the index.