### PR TITLE
Fixed link for Machine Code for Beginners

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -755,7 +755,7 @@
 #### Non-X86
 
 * [Easy 6502](http://skilldrick.github.io/easy6502/) - Nick Morgan
-* [Machine Code for Beginners [Z80 and 6502 CPUs]](http://www.worldofspectrum.org/infoseekid.cgi?id=2000227) - Lisa Watts and Mike Wharton (PDF)
+* [Machine Code for Beginners [Z80 and 6502 CPUs]](https://usborne.com/browse-books/features/computer-and-coding-books/) - Lisa Watts and Mike Wharton (PDF) *(Scroll to bottom and click on book cover)*
 * [Machine Language for Beginners](https://archive.org/details/ataribooks-machine-language-for-beginners) - Richard Mansfield [6502 CPU]
 * [Programmed Introduction to MIPS Assembly Language](http://chortle.ccsu.edu/AssemblyTutorial/index.html)
 


### PR DESCRIPTION
Original linked to a page whose download links were all broken. Linked instead to publisher's website, where the book can be downloaded for free.