### PR TITLE
Fix grammar typo for Azerbaijani docs reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Please read [CONTRIBUTING](/CONTRIBUTING.md).
 
 ### In Other Spoken Languages
 + Arabic: [github](/free-programming-books-ar.md)
-+ Azerbaijan: [github](/free-programming-books-az.md)
++ Azerbaijani: [github](/free-programming-books-az.md)
 + Bulgarian: [github](/free-programming-books-bg.md)
 + Chinese: [github](/free-programming-books-zh.md)
 + Czech: [github](/free-programming-books-cs.md)


### PR DESCRIPTION
There is a typo in Azerbaijani docs reference. "Azerbaijan" (country) should be changed to "Azerbaijani" (language).