### PR TITLE
Add free eBook: The Road to learn React

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1382,6 +1382,10 @@ For resources on Angular, Backbone, D3, Dojo, Ember, Express, jQuery, Knockout, 
 * [The Node Beginner Book](http://nodebeginner.org)
 
 
+#### React.js
+
+* [The Road to learn React - Build a Hacker News App along the Way](https://leanpub.com/the-road-to-learn-react), [Open Source](https://github.com/rwieruch/the-road-to-learn-react)
+
 ### Jenkins
 
 * [Jenkins: The Definitive Guide](http://www.bogotobogo.com/DevOps/Jenkins/images/Intro_install/jenkins-the-definitive-guide.pdf) (PDF)


### PR DESCRIPTION
The book is perceived as open source book to learn React. People like and share it in the community. I would love to see it in the list of free React books, even though people can pay what they want to support events like this: https://www.robinwieruch.de/giving-back-by-learning-react/

cc @eshellman 