### PR TITLE
Add free eBook: The Road to learn React

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -74,6 +74,7 @@
 * [JavaScript](#javascript)
   * [Javascript frameworks](#javascript-frameworks)
   * [Node.js](#nodejs)
+  * [React.js](#reactjs)
 * [Jenkins](#jenkins)
 * [Julia](#julia)
 * [Language Agnostic](#language-agnostic)
@@ -1400,6 +1401,11 @@ For resources on Angular, Backbone, D3, Dojo, Ember, Express, jQuery, Knockout, 
 * [Node: Up and Running](http://chimera.labs.oreilly.com/books/1234000001808/index.html) - Tom Hughes-Croucher
 * [Node.js Succinctly, Syncfusion](https://www.syncfusion.com/resources/techportal/ebooks/nodejs) (PDF, Kindle) *(Just fill the fields with any values)*
 * [The Node Beginner Book](http://nodebeginner.org)
+
+
+#### React.js
+
+* [The Road to learn React - Build a Hacker News App along the Way](https://leanpub.com/the-road-to-learn-react), [Open Source](https://github.com/rwieruch/the-road-to-learn-react)
 
 
 ### Jenkins


### PR DESCRIPTION
The book is perceived as open source book to learn React. People like and share it in the community. I would love to see it in the list of free React books, even though people can pay what they want to support events like this: https://www.robinwieruch.de/giving-back-by-learning-react/